### PR TITLE
fix(ci): add harden runner for security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Harden runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.12.2
+        with:
+          disable-sudo-and-containers: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            *.github.com:443
+            registry.npmjs.org:443
 
-    - name: Setup Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: lts/jod # 22.x "Jod"
-        cache: 'npm'
-        cache-dependency-path: package-lock.json
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: lts/jod # 22.x "Jod"
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
-    - name: Run linter
-      run: npm run lint
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Run build
-      run: npm run build
+      - name: Run linter
+        run: npm run lint
 
-    - name: Run tests
-      run: npm run test:cov
+      - name: Run build
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test:cov

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.12.2
+        with:
+          disable-sudo-and-containers: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            *.github.com:443
+            registry.npmjs.org:443
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Cette PR ajoute l’utilisation de step-security/harden-runner afin de renforcer la sécurité des workflows CI, en particulier dans un dépôt public où le risque d’abus est plus élevé. Le runner est configuré pour bloquer l’accès réseau par défaut et n’autoriser que les endpoints nécessaires (GitHub et npm), réduisant ainsi la surface d’attaque en cas de dépendance compromise ou de tentative d’exfiltration de données. L’option désactivant sudo et les conteneurs limite également les privilèges du runner, apportant une protection supplémentaire contre l’exécution malveillante de code.