### PR TITLE
fix(realtime): #46 - use gpt-realtime-mini

### DIFF
--- a/src/main/config/realtime-limits.ts
+++ b/src/main/config/realtime-limits.ts
@@ -9,7 +9,7 @@ export const REALTIME_LIMITS = {
   MAX_TURNS_PER_SESSION: 20,
 
   // Modèle OpenAI à utiliser (vérifier le prix avant de changer !)
-  MODEL: 'gpt-4o-mini-realtime-preview',
+  MODEL: 'gpt-realtime-mini',
 
   // Limite de taille pour un message texte reçu (si on utilise du texte en entrée)
   MAX_TEXT_INPUT_LENGTH: 1000,

--- a/src/main/services/ConversationService.ts
+++ b/src/main/services/ConversationService.ts
@@ -7,6 +7,7 @@ import { OpenAIService } from './OpenAIService';
 const PRICING_RATES: Record<string, { prompt: number; completion: number }> = {
   'gpt-4o-realtime-preview': { prompt: 0.1, completion: 0.2 }, // ~$100/1M in, $200/1M out
   'gpt-4o-mini-realtime-preview': { prompt: 0.01, completion: 0.02 }, // ~$10/1M in, $20/1M out
+  'gpt-realtime-mini': { prompt: 0.01, completion: 0.02 }, // ~$10/1M in, $20/1M out
   'gpt-4o': { prompt: 0.005, completion: 0.015 },
   'gpt-4o-mini': { prompt: 0.00015, completion: 0.0006 },
   default: { prompt: 0.01, completion: 0.03 }, // Fallback


### PR DESCRIPTION
## Contexte
Closes #46.

Le backend utilisait encore le modèle OpenAI Realtime preview `gpt-4o-mini-realtime-preview`. Le projet utilise maintenant son successeur plus récent `gpt-realtime-mini`, sans changement fonctionnel attendu côté client VR.

## Changements
- Remplacement du modèle Realtime configuré par `gpt-realtime-mini`
- Ajout de `gpt-realtime-mini` dans les tarifs internes utilisés pour journaliser le coût IA

## Impact
- Même ordre de prix que le modèle mini preview précédent
- Aucun changement attendu dans le protocole WebSocket côté client VR
- Améliore la cohérence du projet en évitant un modèle preview obsolète

## Validation
- `npm run build`
- `npm test`

## Revue
Peer review à réaliser par le chef de projet avant merge vers `dev`.